### PR TITLE
chore(ci/docker): refine Docker publish workflow and metadata

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   docker:
-    name: Build & Publish Docker Image
+    name: Build and Push Docker Image
     runs-on: ubuntu-latest
 
     permissions:
@@ -25,14 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          driver-opts: image=moby/buildkit:latest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -52,13 +48,13 @@ jobs:
           VERSION="${GIT_TAG}${DIRTY}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push multi-arch Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/echo-back:latest
             ${{ secrets.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: lucho00cuba/echo-back
+  IMAGE_NAME: 0lucho0/echo-back
 
 jobs:
   docker:
@@ -28,16 +28,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all  # include arm64
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
+      #   with:
+      #     platforms: all  # include arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          install: true
-          driver-opts: image=moby/buildkit:latest
+        # with:
+        #   install: true
+        #   driver-opts: image=moby/buildkit:latest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -63,7 +63,8 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -7,47 +7,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate-branch:
-    name: Validate Release Branch
-    runs-on: ubuntu-latest
-    outputs:
-      proceed: ${{ steps.check.outputs.proceed }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect source branch for tag
-        id: check
-        run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          BRANCH=$(git branch -r --contains "tags/${TAG_NAME}" | grep 'origin/release/' | sed 's|origin/||' | head -n 1 || true)
-
-          if [[ "$BRANCH" == release/* ]]; then
-            echo "✅ Valid release branch: $BRANCH"
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "❌ Tag does not belong to a release/* branch. Skipping publish."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-          fi
-
   docker:
-    name: Docker Build & Publish
+    name: Build & Publish Docker Image
     runs-on: ubuntu-latest
-    needs: validate-branch
-    if: needs.validate-branch.outputs.proceed == 'true'
 
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -67,16 +40,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, version)
+      - name: Extract metadata
         id: meta
         run: |
           GIT_COMMIT=$(git rev-parse --short HEAD)
-          GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          GIT_TAG="${GITHUB_REF#refs/tags/}"
           DIRTY=""
           if [ -n "$(git status --porcelain)" ]; then
             DIRTY="-dirty"
           fi
-          VERSION="${GIT_TAG:-${GIT_COMMIT}}${DIRTY}"
+          VERSION="${GIT_TAG}${DIRTY}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build and push multi-arch Docker image

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -56,8 +56,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/echo-back:latest
-            ${{ secrets.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}
+            ${{ env.DOCKER_USERNAME }}/echo-back:latest
+            ${{ env.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -10,9 +10,12 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  IMAGE_NAME: lucho00cuba/echo-back
+
 jobs:
   docker:
-    name: Build and Push Docker Image
+    name: Build & Publish Docker Image
     runs-on: ubuntu-latest
 
     permissions:
@@ -25,10 +28,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all  # include arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
+          driver-opts: image=moby/buildkit:latest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -48,7 +57,7 @@ jobs:
           VERSION="${GIT_TAG}${DIRTY}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push Docker image
+      - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -56,8 +65,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ vars.DOCKER_USERNAME }}/echo-back:latest
-            ${{ vars.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -56,8 +56,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.DOCKER_USERNAME }}/echo-back:latest
-            ${{ env.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}
+            ${{ vars.DOCKER_USERNAME }}/echo-back:latest
+            ${{ vars.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -58,7 +58,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/echo-back:latest
             ${{ secrets.DOCKER_USERNAME }}/echo-back:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -71,3 +71,10 @@ jobs:
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
+      
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/test-and-format.yaml
+++ b/.github/workflows/test-and-format.yaml
@@ -60,8 +60,10 @@ jobs:
         with:
           name: coverage.out
           path: src/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: src/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docker Publish](https://github.com/Lucho00Cuba/echo-back/actions/workflows/docker-publish.yaml/badge.svg)](https://github.com/Lucho00Cuba/echo-back/actions/workflows/docker-publish.yaml)
 [![codecov](https://codecov.io/gh/lucho00cuba/echo-back/graph/badge.svg?token=U7Z7UXUXZB)](https://codecov.io/gh/lucho00cuba/echo-back)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/lucho00cuba/echo-back?filename=src%2Fgo.mod)](https://github.com/lucho00cuba/echo-back)
-[![Docker](https://img.shields.io/docker/v/lucho00cuba/echo-back?label=docker&sort=semver)](https://hub.docker.com/r/lucho00cuba/echo-back)
+[![Docker](https://img.shields.io/docker/v/0lucho0/echo-back?label=docker&sort=semver)](https://hub.docker.com/r/0lucho0/echo-back)
 [![License](https://img.shields.io/github/license/lucho00cuba/echo-back)](./LICENSE)
 [![Last Commit](https://img.shields.io/github/last-commit/lucho00cuba/echo-back)](https://github.com/lucho00cuba/echo-back/commits/master)
 


### PR DESCRIPTION
This PR refactors and simplifies the Docker publishing process and related metadata in CI/CD workflows.

### ✅ Changes included:
- ➕ Added a Docker Hub description step to improve image metadata visibility.
- 🐳 Refactored Docker publish workflow to support **only `amd64` builds** (removed `arm64` due to QEMU-related issues).
- 🔁 Enabled **conditional Go test execution** (only runs locally, skipped in Docker builds).
- 🔐 Replaced use of `secrets` with **environment variables** for Docker credentials in workflows.
- 🛠 Cleaned up unused workflow steps and build tags.
- 📄 Updated README Docker badge to point to the correct Docker Hub repo.

> ℹ️ Multi-arch support is temporarily disabled due to build issues with `arm64` (QEMU + vet failures).